### PR TITLE
Added 'Monster Picker' and 'Spell Picker' functionality

### DIFF
--- a/5eShapedScripts/lib/entity-lookup.js
+++ b/5eShapedScripts/lib/entity-lookup.js
@@ -44,6 +44,21 @@ module.exports = {
     getAll: function (type) {
         return utils.deepClone(_.values(entities[type]));
     },
+    
+    /**
+     * Gets all of the keys for the specified entity type
+     * @param {string} type - The entity type to retrieve keys for (either 'monster' or 'spell')
+     * @param {boolean} sort - True if the returned array should be sorted alphabetically; false otherwise
+     * @return {Array} An array containing all keys for the specified entity type
+     */
+    getKeys: function (type, sort) {
+        var keys =  _.keys(entities[type]);
+        if (sort) {
+            keys.sort();
+        }
+        return keys;
+    },
+
     logWrap: 'entityLookup',
     toJSON: function () {
         return {monsterCount: _.size(entities.monster), spellCount: _.size(entities.spell)};

--- a/5eShapedScripts/lib/shaped-script.js
+++ b/5eShapedScripts/lib/shaped-script.js
@@ -547,23 +547,35 @@ module.exports = function (logger, myState, roll20, parser, entityLookup) {
         },
 
         importMonstersFromJson: function (options) {
-            var characterProcessors = [];
-            characterProcessors.push(this.hydrateSpellList.bind(this));
-            if (options.all) {
-                options.monsters = entityLookup.getAll('monster');
-                delete options.all;
+            if (options.monsters === undefined && options.all === undefined) {
+                // no monster name supplied, check to see if we have a loaded monsters json
+                var list = entityLookup.getKeys('monster', true);
+                if (_.size(list) > 0) {
+                    // title case the monster names for better display
+                    list.forEach(function (part, index) { list[index] = utils.toTitleCase(part); });
+                    // create a clickable button with a roll query to select a monster from the loaded json
+                    report('Monster Importer', '<a href="!shaped-import-monster --?{Pick a monster|' + list.join('|') + '}">Click to select a monster</a>');
+                } else {
+                    report('Monster Importer', 'Could not find any monsters.<br/>Please ensure you have a properly formatted monsters json file.');
+                }
+            } else {
+                var characterProcessors = [];
+                characterProcessors.push(this.hydrateSpellList.bind(this));
+                if (options.all) {
+                    options.monsters = entityLookup.getAll('monster');
+                    delete options.all;
+                }
+                
+                
+                this.importMonsters(options.monsters.slice(0, 20), options, options.selected.graphic, characterProcessors);
+                options.monsters = options.monsters.slice(20);
+                var self = this;
+                if (!_.isEmpty(options.monsters)) {
+                    setTimeout(function () {
+                        self.importMonstersFromJson(options);
+                    }, 200);
+                }
             }
-
-
-            this.importMonsters(options.monsters.slice(0, 20), options, options.selected.graphic, characterProcessors);
-            options.monsters = options.monsters.slice(20);
-            var self = this;
-            if (!_.isEmpty(options.monsters)) {
-                setTimeout(function () {
-                    self.importMonstersFromJson(options);
-                }, 200);
-            }
-
         },
 
         importMonsters: function (monsters, options, token, characterProcessors) {
@@ -621,7 +633,20 @@ module.exports = function (logger, myState, roll20, parser, entityLookup) {
         },
 
         importSpellsFromJson: function (options) {
-            this.addSpellsToCharacter(options.selected.character, options.spells);
+            if (options.spells === undefined) {
+                // no spell name supplied, check to see if we have a loaded spells json
+                var list = entityLookup.getKeys('spell', true);
+                if (_.size(list) > 0) {
+                    // title case the spell names for better display
+                    list.forEach(function (part, index) { list[index] = utils.toTitleCase(part); });
+                    // create a clickable button with a roll query to select a spell from the loaded json
+                    report('Spell Importer', '<a href="!shaped-import-spell --?{Pick a spell|' + list.join('|') + '}">Click to select a spell</a>');
+                } else {
+                    report('Spell Importer', 'Could not find any spells.<br/>Please ensure you have a properly formatted spells json file.');
+                }
+            } else {
+                this.addSpellsToCharacter(options.selected.character, options.spells);
+            }
         },
 
         addSpellsToCharacter: function (character, spells, noreport) {

--- a/5eShapedScripts/lib/utils.js
+++ b/5eShapedScripts/lib/utils.js
@@ -57,5 +57,16 @@ module.exports = {
     deepClone: function (object) {
         'use strict';
         return JSON.parse(JSON.stringify(object));
+    },
+    
+    /**
+     * Gets a string as 'Title Case' capitalizing the first letter of each word (i.e. 'the grapes of wrath' -> 'The Grapes Of Wrath')
+     * @param {string} s - The string to be converted
+     * @return {string} the supplied string in title case
+     */
+    toTitleCase : function (s) {
+        'use strict';
+        var res = s.replace(/\w\S*/g, function (txt) { return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase(); });
+        return res;
     }
 };


### PR DESCRIPTION
If a !shaped-import-monster or !shaped-import-spell command are called
without a monster or spell name, the script will now:
- determine if any monsters or spells are loaded from json respectively
- if so,  a clickable macro will be built and sent to allow the user to
  pick the monster/spell from a dropdown list (using a roll query)
- if not, will warn the user that no entities have been loaded from json

---

*All new methods documented.
*Respects the new '--all' option

---
